### PR TITLE
Danger zone for deletion info

### DIFF
--- a/app/views/users/deletion_info.html.erb
+++ b/app/views/users/deletion_info.html.erb
@@ -26,13 +26,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
-<%= toolbar title: "#{l('account.deletion_info.heading', :name => h(@user.name))}" %>
-<%= labelled_tabular_form_for :user, :url => user_path(@user), :html => { :method => :delete, :class => 'confirm_required form -bordered -danger-zone' } do |form| %>
-
+<%= labelled_tabular_form_for :user, url: user_path(@user), html: { method: :delete, class: 'confirm_required form danger-zone' } do |form| %>
   <div class='wiki'>
     <section class="form--section">
       <h3 class="form--section-title">
-        <%= l("account.deletion_info.info.#{User.current == @user ? 'self' : 'other'}") %>
+        <%= l('account.deletion_info.heading', name: "<em>#{h(@user.name)}</em>").html_safe %>
       </h3>
 
       <p>
@@ -42,10 +40,19 @@ See doc/COPYRIGHT.rdoc for more details.
       <p>
         <%= l("account.deletion_info.data_consequences.#{User.current == @user ? 'self' : 'other'}") %>
       </p>
-      <div>
-        <%= form.submit l(:button_delete), class: 'button -highlight' %>
-        <%= link_to l(:button_cancel), { :controller => '/my', :action => 'account' },
-              class: 'button' %>
+      <p class="danger-zone--warning">
+        <span class="icon icon-attention2"></span>
+        <span><%= l("account.deletion_info.info.#{User.current == @user ? 'self' : 'other'}") %></span>
+      </p>
+      <p>
+        <%= l("account.deletion_info.login_verification.#{User.current == @user ? 'self' : 'other'}", name: "<em>#{h(@user.name)}</em>").html_safe %>
+      </p>
+      <div class="danger-zone--verification">
+        <input type="text" name="login_verification"/>
+        <%= form.button '', class: 'button -highlight' do
+          concat content_tag :i, '', class: 'button--icon icon-delete'
+          concat content_tag :span, l(:button_delete), class: 'button--text'
+          end %>
       </div>
     </section>
   </div>

--- a/app/views/users/deletion_info.html.erb
+++ b/app/views/users/deletion_info.html.erb
@@ -27,27 +27,28 @@ See doc/COPYRIGHT.rdoc for more details.
 
 ++#%>
 <%= toolbar title: "#{l('account.deletion_info.heading', :name => h(@user.name))}" %>
-<%= labelled_tabular_form_for :user, :url => user_path(@user), :html => { :method => :delete, :class => 'confirm_required' } do |form| %>
+<%= labelled_tabular_form_for :user, :url => user_path(@user), :html => { :method => :delete, :class => 'confirm_required form -bordered -danger-zone' } do |form| %>
 
   <div class='wiki'>
-    <p>
-      <%= l("account.deletion_info.login_consequences.#{User.current == @user ? 'self' : 'other'}") %>
-    </p>
+    <section class="form--section">
+      <h3 class="form--section-title">
+        <%= l("account.deletion_info.info.#{User.current == @user ? 'self' : 'other'}") %>
+      </h3>
 
-    <p>
-      <%= l("account.deletion_info.data_consequences.#{User.current == @user ? 'self' : 'other'}") %>
-    </p>
+      <p>
+        <%= l("account.deletion_info.login_consequences.#{User.current == @user ? 'self' : 'other'}") %>
+      </p>
 
-    <p>
-      <%= l("account.deletion_info.info.#{User.current == @user ? 'self' : 'other'}") %>
-    </p>
+      <p>
+        <%= l("account.deletion_info.data_consequences.#{User.current == @user ? 'self' : 'other'}") %>
+      </p>
+      <div>
+        <%= form.submit l(:button_delete), class: 'button -highlight' %>
+        <%= link_to l(:button_cancel), { :controller => '/my', :action => 'account' },
+              class: 'button' %>
+      </div>
+    </section>
   </div>
-
-  <p>
-    <%= form.submit l(:button_delete), class: 'button -highlight' %>
-    <%= link_to l(:button_cancel), { :controller => '/my', :action => 'account' },
-          class: 'button' %>
-  </p>
 <% end %>
 
 <%= javascript_tag do -%>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -42,6 +42,9 @@ en:
       login_consequences:
         other: "The account will be deleted from the system. Therefore, the user will no longer be able to log in with his current credentials. He/she can choose to become a user of this application again by the means this application grants."
         self: "Your account will be deleted from the system. Therefore, you will no longer be able to log in with your current credentials. If you choose to become a user of this application again, you can do so by using the means this application grants."
+      login_verification:
+        other: "Enter the login %{name} to verify the deletion."
+        self: "Enter your login %{name} to verify the deletion."
     error_inactive_activation_by_mail: >
       Your account has not yet been activated.
       To activate your account, click on the link that was emailed to you.


### PR DESCRIPTION
This changes the DOM of the deletion_info site for the use of the new danger-zone component.
Note that this won't work properly before the merge of https://github.com/opf/openproject/pull/3503.
